### PR TITLE
채팅방 새로 생성하기/기존 채팅방 들어가기 기능 구현

### DIFF
--- a/emotion_classifier.py
+++ b/emotion_classifier.py
@@ -1,0 +1,9 @@
+class EmotionClassifier:
+
+    def __init__(self):
+        from inference import predict_emotion
+
+        self._classifier = predict_emotion
+
+    def classify(self, message: str) -> str:
+        return self._classifier(message)

--- a/main.py
+++ b/main.py
@@ -47,8 +47,8 @@ class ChatRoom:
 chat_rooms: Dict[str, ChatRoom] = {}
 
 
-@app.websocket("/chat/connect/new")
-async def create_new_chat_room(websocket: WebSocket):
+@app.websocket("/chat/connect/new/{username}")
+async def create_new_chat_room(websocket: WebSocket, username: str):
     room_id = str(uuid.uuid4())  # 무작위로 UUID 생성
     chat_rooms[room_id] = ChatRoom(room_id)
 
@@ -57,8 +57,7 @@ async def create_new_chat_room(websocket: WebSocket):
     connection = UserConnection(
         user_id=str(uuid.uuid4()),
         websocket=websocket,
-        # TODO: 유저 이름 추가
-        username="유저이름 추가해주세요!",
+        username=username,
     )
 
     await chat_rooms[room_id].connect(connection)
@@ -81,13 +80,12 @@ async def create_new_chat_room(websocket: WebSocket):
             await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
 
 
-@app.websocket("/chat/{room_id}/connect")
-async def websocket_endpoint(websocket: WebSocket, room_id: str):
+@app.websocket("/chat/{room_id}/connect/{username}")
+async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
     connection = UserConnection(
         user_id=str(uuid.uuid4()),
         websocket=websocket,
-        # TODO: 유저 이름 추가
-        username="유저이름 추가해주세요!",
+        username=username,
     )
 
     await chat_rooms[room_id].connect(connection)

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ async def create_new_chat_room(websocket: WebSocket, username: str):
 
     try:
         await chat_rooms[room_id].broadcast(Message(
-            username='System', message='누군가 방에 입장했습니다.'
+            username='System', message=f'{username}가 방에 입장했습니다.'
         ))
 
         while True:
@@ -77,7 +77,7 @@ async def create_new_chat_room(websocket: WebSocket, username: str):
     except WebSocketDisconnect:
         await chat_rooms[room_id].disconnect(connection)
         if room_id in chat_rooms:
-            await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
+            await chat_rooms[room_id].broadcast(Message(username="System", message=f"{username}가 방에서 나갔습니다."))
 
 
 @app.websocket("/chat/{room_id}/connect/{username}")
@@ -92,7 +92,7 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
 
     try:
         await chat_rooms[room_id].broadcast(Message(
-            username='System', message='누군가 방에 입장했습니다.'
+            username='System', message=f'{username}가 방에 입장했습니다.'
         ))
 
         while True:
@@ -105,7 +105,7 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
     except WebSocketDisconnect:
         await chat_rooms[room_id].disconnect(connection)
         if room_id in chat_rooms:
-            await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
+            await chat_rooms[room_id].broadcast(Message(username="System", message=f"{username}가 방에서 나갔습니다."))
 
 
 @app.get("/chat/rooms")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 import uuid
+from typing import Set, Dict
 
 from fastapi import FastAPI, Request
 from starlette.responses import HTMLResponse
@@ -8,31 +9,34 @@ from starlette.templating import Jinja2Templates
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from connection_manager import ConnectionManager
+from emotion_classifier import EmotionClassifier
 from message import Message
+from mock_emotion_classifier import MockEmotionClassifier
+from user_connection import UserConnection
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 
 connection_manager = ConnectionManager()
 
+# emotion_classifier = EmotionClassifier()
+# m1 import 이슈로 작업할 때는 MockEmotionClassifier 사용
+emotion_classifier = MockEmotionClassifier()
 
-@app.get("/health")
-async def health_check():
-    return {"status": "ok"}
 
 class ChatRoom:
     def __init__(self, room_id):
         self.room_id = room_id
         self.manager = ConnectionManager()
-        self.users = set()  # 사용자 수 추적
+        self.users: Set[UserConnection] = set()  # 사용자 수 추적
 
-    async def connect(self, websocket: WebSocket):
-        await self.manager.connect(websocket)
-        self.users.add(websocket)  # 사용자 추가
+    async def connect(self, connection: UserConnection):
+        await self.manager.connect(connection)
+        self.users.add(connection)  # 사용자 추가
 
-    async def disconnect(self, websocket: WebSocket):
-        await self.manager.disconnect(websocket)
-        self.users.remove(websocket)  # 사용자 제거
+    async def disconnect(self, connection: UserConnection):
+        await self.manager.disconnect(connection)
+        self.users.remove(connection)  # 사용자 제거
         if not self.users:
             del chat_rooms[self.room_id]  # 사용자가 모두 나가면 방 삭제
 
@@ -40,7 +44,7 @@ class ChatRoom:
         await self.manager.broadcast(message)
 
 
-chat_rooms = {}
+chat_rooms: Dict[str, ChatRoom] = {}
 
 
 @app.websocket("/chat/connect/new")
@@ -48,7 +52,16 @@ async def create_new_chat_room(websocket: WebSocket):
     room_id = str(uuid.uuid4())  # 무작위로 UUID 생성
     chat_rooms[room_id] = ChatRoom(room_id)
 
-    await chat_rooms[room_id].connect(websocket)
+    print(chat_rooms)
+
+    connection = UserConnection(
+        user_id=str(uuid.uuid4()),
+        websocket=websocket,
+        # TODO: 유저 이름 추가
+        username="유저이름 추가해주세요!",
+    )
+
+    await chat_rooms[room_id].connect(connection)
 
     try:
         await chat_rooms[room_id].broadcast(Message(
@@ -60,16 +73,24 @@ async def create_new_chat_room(websocket: WebSocket):
             message = Message.parse_raw(data)
 
             await chat_rooms[room_id].broadcast(message)
+            connection.add_message(message)
+
     except WebSocketDisconnect:
-        chat_rooms[room_id].disconnect(websocket)
+        await chat_rooms[room_id].disconnect(connection)
         if room_id in chat_rooms:
             await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
 
 
 @app.websocket("/chat/{room_id}/connect")
 async def websocket_endpoint(websocket: WebSocket, room_id: str):
+    connection = UserConnection(
+        user_id=str(uuid.uuid4()),
+        websocket=websocket,
+        # TODO: 유저 이름 추가
+        username="유저이름 추가해주세요!",
+    )
 
-    await chat_rooms[room_id].connect(websocket)
+    await chat_rooms[room_id].connect(connection)
 
     try:
         await chat_rooms[room_id].broadcast(Message(
@@ -81,11 +102,12 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str):
             message = Message.parse_raw(data)
 
             await chat_rooms[room_id].broadcast(message)
+            connection.add_message(message)
+
     except WebSocketDisconnect:
-        chat_rooms[room_id].disconnect(websocket)
+        await chat_rooms[room_id].disconnect(connection)
         if room_id in chat_rooms:
             await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
-
 
 
 @app.websocket("/chat/connect")
@@ -93,8 +115,12 @@ async def websocket_endpoint(
         websocket: WebSocket,
         username: str | None = None,
 ):
-    user = UserConnection(user_id=str(uuid.uuid4()), username=username, websocket=websocket)
-    await connection_manager.connect(user)
+    connection = UserConnection(
+        user_id=str(uuid.uuid4()),
+        username=username,
+        websocket=websocket,
+    )
+    await connection_manager.connect(connection)
 
     try:
         await connection_manager.broadcast(Message(
@@ -106,10 +132,10 @@ async def websocket_endpoint(
             message = Message.parse_raw(data)
 
             await connection_manager.broadcast(message)
-            user.add_message(message)
+            connection.add_message(message)
 
     except WebSocketDisconnect:
-        connection_manager.disconnect(user)
+        connection_manager.disconnect(connection)
         await connection_manager.broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
 
 
@@ -127,36 +153,44 @@ async def root(request: Request):
     )
 
 
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}
+
+
 async def broadcast_emotion_message():
     while True:
         try:
             await asyncio.sleep(20)
 
-            connections = connection_manager.get_connections()
-            if not connections:
-                continue
+            for key in chat_rooms.keys():
+                manager = chat_rooms[key].manager
 
-            chose_connection: UserConnection = random.choice(connections)
+                connections = manager.get_connections()
+                if not connections:
+                    continue
 
-            messages = chose_connection.get_messages()
-            if len(messages) == 0:
-                await connection_manager.broadcast(
+                chose_connection: UserConnection = random.choice(connections)
+
+                messages = chose_connection.get_messages()
+                if len(messages) == 0:
+                    await manager.broadcast(
+                        Message(
+                            username="System",
+                            message=f"메시지를 입력해보세요!",
+                        )
+                    )
+                    continue
+                last_message = messages[-1].message
+
+                emotion_text = emotion_classifier.classify(last_message)
+
+                await manager.broadcast(
                     Message(
                         username="System",
-                        message=f"메시지를 입력해보세요!",
+                        message=f"{chose_connection.username}의 {emotion_text} 느껴집니다.",
                     )
                 )
-                continue
-            last_message = messages[-1].message
-
-            emotion_text = predict_emotion(last_message)
-
-            await connection_manager.broadcast(
-                Message(
-                    username="System",
-                    message=f"{chose_connection.username}의 {emotion_text} 느껴집니다.",
-                )
-            )
 
         except Exception as e:
             print(e)

--- a/main.py
+++ b/main.py
@@ -64,6 +64,11 @@ async def create_new_chat_room(websocket: WebSocket, username: str):
     await chat_rooms[room_id].connect(connection)
 
     try:
+        # 클라이언트에게 매개변수를 포함한 초기 메시지 전송
+        await chat_rooms[room_id].broadcast(Message(
+            username='Root', message=chat_rooms[room_id].room_name
+        ))
+
         await chat_rooms[room_id].broadcast(Message(
             username='System', message=f'{username}가 방에 입장했습니다.'
         ))
@@ -92,6 +97,11 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
     await chat_rooms[room_id].connect(connection)
 
     try:
+        # 클라이언트에게 매개변수를 포함한 초기 메시지 전송
+        await chat_rooms[room_id].broadcast(Message(
+            username='Root', message=chat_rooms[room_id].room_name
+        ))
+
         await chat_rooms[room_id].broadcast(Message(
             username='System', message=f'{username}가 방에 입장했습니다.'
         ))

--- a/main.py
+++ b/main.py
@@ -19,9 +19,9 @@ templates = Jinja2Templates(directory="templates")
 
 connection_manager = ConnectionManager()
 
-# emotion_classifier = EmotionClassifier()
+emotion_classifier = EmotionClassifier()
 # m1 import 이슈로 작업할 때는 MockEmotionClassifier 사용
-emotion_classifier = MockEmotionClassifier()
+# emotion_classifier = MockEmotionClassifier()
 
 
 class ChatRoom:

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ emotion_classifier = MockEmotionClassifier()
 class ChatRoom:
     def __init__(self, room_id):
         self.room_id = room_id
+        self.room_name = f"room {uuid.UUID(room_id).int % 10000}"
         self.manager = ConnectionManager()
         self.users: Set[UserConnection] = set()  # 사용자 수 추적
 
@@ -110,7 +111,7 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
 
 @app.get("/chat/rooms")
 async def get_rooms():
-    return list(chat_rooms.keys())
+    return [value.room_name for value in chat_rooms.values()]
 
 
 # root

--- a/main.py
+++ b/main.py
@@ -16,16 +16,22 @@ templates = Jinja2Templates(directory="templates")
 
 manager = ConnectionManager()
 
+
 class ChatRoom:
     def __init__(self, room_id):
         self.room_id = room_id
         self.manager = ConnectionManager()
+        self.users = set()  # 사용자 수 추적
 
     async def connect(self, websocket: WebSocket):
         await self.manager.connect(websocket)
+        self.users.add(websocket)  # 사용자 추가
 
     async def disconnect(self, websocket: WebSocket):
         await self.manager.disconnect(websocket)
+        self.users.remove(websocket)  # 사용자 제거
+        if not self.users:
+            del chat_rooms[self.room_id]  # 사용자가 모두 나가면 방 삭제
 
     async def broadcast(self, message: Message):
         await self.manager.broadcast(message)
@@ -34,33 +40,10 @@ class ChatRoom:
 chat_rooms = {}
 
 
-@app.websocket("/chat/{room_id}/connect")
-async def websocket_endpoint(websocket: WebSocket, room_id: str):
-    if room_id not in chat_rooms:
-        chat_rooms[room_id] = ChatRoom(room_id)
-
-    await chat_rooms[room_id].connect(websocket)
-
-    try:
-        await chat_rooms[room_id].broadcast(Message(
-            username='System', message='누군가 방에 입장했습니다.'
-        ))
-
-        while True:
-            data = await websocket.receive_text()
-            message = Message.parse_raw(data)
-
-            await chat_rooms[room_id].broadcast(message)
-    except WebSocketDisconnect:
-        await chat_rooms[room_id].disconnect(websocket)
-        await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
-
-
-@app.websocket("/chat/new/connect")
+@app.websocket("/chat/connect/new")
 async def create_new_chat_room(websocket: WebSocket):
     room_id = str(uuid.uuid4())  # 무작위로 UUID 생성
-    if room_id not in chat_rooms:
-        chat_rooms[room_id] = ChatRoom(room_id)
+    chat_rooms[room_id] = ChatRoom(room_id)
 
     await chat_rooms[room_id].connect(websocket)
 
@@ -75,8 +58,30 @@ async def create_new_chat_room(websocket: WebSocket):
 
             await chat_rooms[room_id].broadcast(message)
     except WebSocketDisconnect:
-        await chat_rooms[room_id].disconnect(websocket)
-        await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
+        chat_rooms[room_id].disconnect(websocket)
+        if room_id in chat_rooms:
+            await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
+
+
+@app.websocket("/chat/{room_id}/connect")
+async def websocket_endpoint(websocket: WebSocket, room_id: str):
+
+    await chat_rooms[room_id].connect(websocket)
+
+    try:
+        await chat_rooms[room_id].broadcast(Message(
+            username='System', message='누군가 방에 입장했습니다.'
+        ))
+
+        while True:
+            data = await websocket.receive_text()
+            message = Message.parse_raw(data)
+
+            await chat_rooms[room_id].broadcast(message)
+    except WebSocketDisconnect:
+        chat_rooms[room_id].disconnect(websocket)
+        if room_id in chat_rooms:
+            await chat_rooms[room_id].broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
 
 
 # 입장 버튼 누른 이후
@@ -97,6 +102,11 @@ async def websocket_endpoint(websocket: WebSocket):
     except WebSocketDisconnect:
         manager.disconnect(websocket)
         await manager.broadcast(Message(username="System", message="누군가 방에서 나갔습니다."))
+
+
+@app.get("/chat/rooms")
+async def get_rooms():
+    return list(chat_rooms.keys())
 
 
 # root

--- a/mock_emotion_classifier.py
+++ b/mock_emotion_classifier.py
@@ -1,0 +1,10 @@
+from emotion_classifier import EmotionClassifier
+
+
+class MockEmotionClassifier(EmotionClassifier):
+
+    def __init__(self):
+        pass
+
+    def classify(self, message: str) -> str:
+        return "아무 감정이"

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -367,6 +367,7 @@
 
     createRoomButton.addEventListener('click', function () {
         const username = document.getElementById('onboardingUsernameInput').value;
+        usernameInput.value = username;
 
         if (!username) {
             alert('사용자 이름을 입력해주세요.');
@@ -402,6 +403,8 @@
     joinRoomButton.addEventListener('click', async function () {
         onboardingContainer.classList.add('hidden');
         roomListContainer.classList.remove('hidden');
+
+        usernameInput.value = document.getElementById('onboardingUsernameInput').value;
 
         const rooms = await fetchRoomList();
         showRoomList(rooms);

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -53,7 +53,7 @@
         <line x1="8" x2="8" y1="2" y2="4"></line>
         <line x1="16" x2="16" y1="2" y2="4"></line>
       </svg>
-      <h1 class="text-lg font-semibold">Chat Rooms</h1>
+      <h1 id="room-name" class="text-lg font-semibold">Chat Rooms</h1>
     </div>
     <div class="flex items-center gap-2">
       <button class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-10 w-10 rounded-full">
@@ -222,6 +222,7 @@
     const roomList = document.getElementById('roomList');
     const usernameInput = document.getElementById('usernameInput');
     const messages = document.getElementById('messages');
+    const roomName = document.getElementById("room-name");
 
     let userName = `익명${(Math.random()).toString().substring(2, 6)}`;
     let ws = null;
@@ -342,7 +343,12 @@
 
         ws.onmessage = function (event) {
             const message = JSON.parse(event.data);
-            addMessage(message.username, message.message, new Date().toLocaleTimeString());
+            if (message.username === "Root"){
+                roomName.innerText = message.message
+            }
+            else {
+                addMessage(message.username, message.message, new Date().toLocaleTimeString());
+            }
         };
 
         ws.onclose = function () {
@@ -377,7 +383,11 @@
 
         ws.onmessage = function (event) {
             const message = JSON.parse(event.data);
-            addMessage(message.username, message.message, new Date().toLocaleTimeString());
+            if (message.username === "Root") {
+                roomName.innerText = message.message
+            } else {
+                addMessage(message.username, message.message, new Date().toLocaleTimeString());
+            }
         };
 
         ws.onclose = function () {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -223,7 +223,7 @@
     const usernameInput = document.getElementById('usernameInput');
     const messages = document.getElementById('messages');
 
-    let userName = `익명#${(Math.random()).toString().substring(2, 6)}`;
+    let userName = `익명${(Math.random()).toString().substring(2, 6)}`;
     let ws = null;
 
     onboardingUsernameInput.value = userName;
@@ -323,6 +323,7 @@
 
     async function joinRoom(roomId) {
         const username = document.getElementById('onboardingUsernameInput').value;
+        usernameInput.value = username;
 
         if (!username) {
             alert('사용자 이름을 입력해주세요.');
@@ -333,7 +334,7 @@
         roomListContainer.classList.add('hidden');
         chatContainer.classList.remove('hidden');
 
-        ws = new WebSocket(`ws://localhost:8000/chat/${roomId}/connect`);
+        ws = new WebSocket(`ws://localhost:8000/chat/${roomId}/connect/${username}`);
 
         ws.onopen = function () {
             console.log("Connected to WebSocket server");
@@ -368,7 +369,7 @@
         onboardingContainer.classList.add('hidden');
         chatContainer.classList.remove('hidden');
 
-        ws = new WebSocket('ws://localhost:8000/chat/connect/new');
+        ws = new WebSocket(`ws://localhost:8000/chat/connect/new/${username}`);
 
         ws.onopen = function () {
             console.log("Connected to WebSocket server");

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -19,6 +19,14 @@
     </div>
 </div>
 
+<div id="roomListContainer" class="hidden min-h-screen flex justify-center items-center">
+    <div class="max-w-md w-full bg-white p-8 rounded shadow-lg">
+        <h1 class="text-xl font-bold mb-4">채팅방 선택</h1>
+        <ul id="roomList" class="mb-4"></ul>
+        <button id="backButton" class="w-full bg-gray-500 text-white py-2 rounded hover:bg-gray-600 mt-2">뒤로</button>
+    </div>
+</div>
+
 <!--?수정은 여기 overflow hidden 을 제거-->
 <div id="chatContainer" class="hidden flex h-screen w-full flex-col bg-gray-100 overflow-hidden">
   <header class="flex h-14 shrink-0 items-center justify-between border-b bg-white px-4">
@@ -207,12 +215,15 @@
 <script>
     const onboardingUsernameInput = document.getElementById('onboardingUsernameInput');
     const enterButton = document.getElementById('enterButton');
-    const createRoomButton = document.getElementById('createRoomButton')
+    const createRoomButton = document.getElementById('createRoomButton');
+    const joinRoomButton = document.getElementById('joinRoomButton');
+    const backButton = document.getElementById('backButton');
     const onboardingContainer = document.getElementById('onboardingContainer');
     const chatContainer = document.getElementById('chatContainer');
+    const roomListContainer = document.getElementById('roomListContainer');
+    const roomList = document.getElementById('roomList');
     const usernameInput = document.getElementById('usernameInput');
     const messages = document.getElementById('messages');
-
 
     let userName = `익명#${(Math.random()).toString().substring(2, 6)}`;
     let ws = null;
@@ -239,29 +250,18 @@
     }
 
     function createMessageElement(messageContent, timestamp) {
-        // 메시지 요소를 생성합니다.
         const messageElement = document.createElement('div');
         messageElement.classList.add('flex', 'items-start', 'gap-3', 'justify-end', 'mt-5', 'mb-5');
-
-        // 내용을 포함하는 레이아웃을 생성합니다.
         const messageLayout = document.createElement('div');
         messageLayout.classList.add('rounded-lg', 'bg-blue-500', 'p-3', 'text-white', 'shadow-sm');
-
-        // 메시지 내용을 추가합니다.
         const messageContentElement = document.createElement('div');
         messageContentElement.textContent = messageContent;
         messageLayout.appendChild(messageContentElement);
-
-        // 타임스탬프를 추가합니다.
         const timestampElement = document.createElement('div');
         timestampElement.textContent = timestamp;
         timestampElement.classList.add('mt-2', 'text-xs');
         messageLayout.appendChild(timestampElement);
-
-        // 메시지 요소에 레이아웃을 추가합니다.
         messageElement.appendChild(messageLayout);
-
-        // 보낸 사람 아이콘을 추가합니다.
         const senderIcon = document.createElement('span');
         senderIcon.classList.add('relative', 'flex', 'h-10', 'w-10', 'overflow-hidden', 'rounded-full', 'shrink-0');
         const senderInitials = document.createElement('span');
@@ -269,55 +269,37 @@
         senderInitials.textContent = 'CN'; // 여기에 보낸 사람의 이니셜을 넣으십시오.
         senderIcon.appendChild(senderInitials);
         messageElement.appendChild(senderIcon);
-
         return messageElement;
     }
+
     function createOtherElement(name, message, timestamp) {
-        // 메시지를 감싸는 div 요소 생성
         const messageDiv = document.createElement('div');
         messageDiv.classList.add('flex', 'items-start', 'gap-3', 'mt-5', 'mb-5');
-
-        // 프로필 이미지를 감싸는 span 요소 생성
         const profileImageSpan = document.createElement('span');
         profileImageSpan.classList.add('relative', 'flex', 'h-10', 'w-10', 'overflow-hidden', 'rounded-full', 'shrink-0');
-
-        // 프로필 이미지 생성 및 설정
         const profileImage = document.createElement('span');
         profileImage.classList.add('flex', 'h-full', 'w-full', 'items-center', 'justify-center', 'rounded-full', 'bg-muted');
         profileImage.textContent = name.charAt(0); // 이름의 첫 글자를 프로필 이미지로 사용
         profileImageSpan.appendChild(profileImage);
-
-        // 메시지 내용을 감싸는 div 요소 생성
         const messageContentDiv = document.createElement('div');
         messageContentDiv.classList.add('rounded-lg', 'bg-white', 'p-3', 'shadow-sm');
-
-        // 이름을 표시하는 div 요소 생성 및 설정
         const nameDiv = document.createElement('div');
         nameDiv.classList.add('font-medium');
         nameDiv.textContent = name;
-
-        // 메시지 내용을 표시하는 div 요소 생성 및 설정
         const messageDivInner = document.createElement('div');
         messageDivInner.classList.add('text-sm', 'text-gray-500');
         messageDivInner.textContent = message;
-
-        // 타임스탬프를 표시하는 div 요소 생성 및 설정
         const timestampDiv = document.createElement('div');
         timestampDiv.classList.add('mt-2', 'text-xs', 'text-gray-500');
         timestampDiv.textContent = timestamp;
-
-        // 생성한 요소들을 조립하여 메시지 div에 추가
         messageContentDiv.appendChild(nameDiv);
         messageContentDiv.appendChild(messageDivInner);
         messageContentDiv.appendChild(timestampDiv);
-
         messageDiv.appendChild(profileImageSpan);
         messageDiv.appendChild(messageContentDiv);
-
         return messageDiv;
     }
 
-    // 새 메시지를 추가하는 함수
     function addMessage(messageContent, timestamp, isSystem) {
         const messagesContainer = document.getElementById('chatspace');
         let messageElement;
@@ -326,93 +308,117 @@
         else
             messageElement = createMessageElement(messageContent, timestamp);
         messagesContainer.appendChild(messageElement);
-        // 스크롤을 맨 아래로 이동합니다.
         messagesContainer.scrollTop = messagesContainer.scrollHeight;
     }
 
-    enterButton.addEventListener('click', function () {
+    async function fetchRoomList() {
+        const response = await fetch('http://localhost:8000/chat/rooms');
+        const rooms = await response.json();
+        return rooms;
+    }
+
+    function showRoomList(rooms) {
+        roomList.innerHTML = ''; // 기존 목록 초기화
+        rooms.forEach(room => {
+            const roomItem = document.createElement('li');
+            roomItem.textContent = room;
+            roomItem.classList.add('p-2', 'hover:bg-gray-200', 'cursor-pointer');
+            roomItem.addEventListener('click', function () {
+                joinRoom(room);
+            });
+            roomList.appendChild(roomItem);
+        });
+    }
+
+    async function joinRoom(roomId) {
         const username = document.getElementById('onboardingUsernameInput').value;
 
         if (!username) {
-            alert('사용자 이름을 입력하세요.');
+            alert('사용자 이름을 입력해주세요.');
             return;
         }
-
-        setUserName(username)
-        usernameInput.value = userName
-
-        // TODO: env 및 도메인으로 변경
-        ws = new WebSocket(`ws://localhost:8000/chat/connect`);
-
-        ws.onmessage = function (event) {
-            const data = JSON.parse(event.data);
-            if (data.username === "[System]")
-                addMessage(`${data.username}: ${data.message}`, "10:46 AM", true);
-            else
-                addMessage(`${data.username}: ${data.message}`, "10:46 AM", false);
-        };
-
-        ws.onclose = function (event) {
-            const message = document.createElement('div');
-            message.classList.add('message');
-            message.textContent = "연결이 종료되었습니다.";
-
-            messages.appendChild(message);
-            messages.scrollTop = messages.scrollHeight;
-        };
 
         onboardingContainer.classList.add('hidden');
+        roomListContainer.classList.add('hidden');
         chatContainer.classList.remove('hidden');
-    });
 
-    createRoomButton.addEventListener('click', function() {
-        const username = document.getElementById('onboardingUsernameInput').value;
-
-        if (!username) {
-            alert('사용자 이름을 입력하세요.');
-            return;
-        }
-
-        setUserName(username);
-        usernameInput.value = userName;
-
-        ws = new WebSocket(`ws://localhost:8000/chat/new/connect`);
+        ws = new WebSocket(`ws://localhost:8000/chat/${roomId}/connect`);
 
         ws.onopen = function () {
-            ws.send(JSON.stringify({username: "System", message: `${username}님이 채팅방을 생성했습니다.`}));
+            console.log("Connected to WebSocket server");
         };
 
         ws.onmessage = function (event) {
-            const data = JSON.parse(event.data);
-            if (data.username === "System")
-                addMessage(`${data.username}: ${data.message}`, "10:46 AM", true);
-            else
-                addMessage(`${data.username}: ${data.message}`, "10:46 AM", false);
+            const message = JSON.parse(event.data);
+            addMessage(message.message, new Date().toLocaleTimeString(), message.username === 'System');
         };
 
-        ws.onclose = function (event) {
-            const message = document.createElement('div');
-            message.classList.add('message');
-            message.textContent = "연결이 종료되었습니다.";
-
-            messages.appendChild(message);
-            messages.scrollTop = messages.scrollHeight;
+        ws.onclose = function () {
+            console.log("WebSocket connection closed");
+            ws = null;
         };
+
+        ws.onerror = function (error) {
+            console.error("WebSocket error:", error);
+        };
+
+        setUserName(username);
+    }
+
+    createRoomButton.addEventListener('click', function () {
+        const username = document.getElementById('onboardingUsernameInput').value;
+
+        if (!username) {
+            alert('사용자 이름을 입력해주세요.');
+            return;
+        }
 
         onboardingContainer.classList.add('hidden');
         chatContainer.classList.remove('hidden');
+
+        ws = new WebSocket('ws://localhost:8000/chat/connect/new');
+
+        ws.onopen = function () {
+            console.log("Connected to WebSocket server");
+        };
+
+        ws.onmessage = function (event) {
+            const message = JSON.parse(event.data);
+            addMessage(message.message, new Date().toLocaleTimeString(), message.username === 'System');
+        };
+
+        ws.onclose = function () {
+            console.log("WebSocket connection closed");
+            ws = null;
+        };
+
+        ws.onerror = function (error) {
+            console.error("WebSocket error:", error);
+        };
+
+        setUserName(username);
     });
 
-    document.getElementById('sendButton').addEventListener('click', function () {
-        sendMessage();
+    joinRoomButton.addEventListener('click', async function () {
+        onboardingContainer.classList.add('hidden');
+        roomListContainer.classList.remove('hidden');
+
+        const rooms = await fetchRoomList();
+        showRoomList(rooms);
     });
+
+    backButton.addEventListener('click', function () {
+        roomListContainer.classList.add('hidden');
+        onboardingContainer.classList.remove('hidden');
+    });
+
+    document.getElementById('sendButton').addEventListener('click', sendMessage);
 
     document.getElementById('messageInput').addEventListener('keypress', function (event) {
         if (event.key === 'Enter') {
             sendMessage();
         }
     });
-
 </script>
 </body>
 </html>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -291,11 +291,11 @@
         return messageDiv;
     }
 
-    function addMessage(messageContent, timestamp, isSystem) {
+    function addMessage(name, messageContent, timestamp) {
         const messagesContainer = document.getElementById('chatspace');
         let messageElement;
-        if (isSystem)
-            messageElement = createOtherElement("System", messageContent, timestamp)
+        if (name === "System" || userName !== name)
+            messageElement = createOtherElement(name, messageContent, timestamp)
         else
             messageElement = createMessageElement(messageContent, timestamp);
         messagesContainer.appendChild(messageElement);
@@ -341,7 +341,7 @@
 
         ws.onmessage = function (event) {
             const message = JSON.parse(event.data);
-            addMessage(message.message, new Date().toLocaleTimeString(), message.username === 'System');
+            addMessage(message.username, message.message, new Date().toLocaleTimeString());
         };
 
         ws.onclose = function () {
@@ -376,7 +376,7 @@
 
         ws.onmessage = function (event) {
             const message = JSON.parse(event.data);
-            addMessage(message.message, new Date().toLocaleTimeString(), message.username === 'System');
+            addMessage(message.username, message.message, new Date().toLocaleTimeString());
         };
 
         ws.onclose = function () {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -14,6 +14,8 @@
         <input type="text" id="onboardingUsernameInput" placeholder="사용자 이름"
                class="w-full mb-4 p-2 rounded border border-gray-300 focus:outline-none focus:ring focus:border-blue-500">
         <button id="enterButton" class="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600">입장</button>
+        <button id="createRoomButton" class="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600">새 채팅방 만들기</button>
+        <button id="joinRoomButton" class="w-full bg-green-500 text-white py-2 rounded hover:bg-green-600 mt-2">기존 채팅방에 참여하기</button>
     </div>
 </div>
 
@@ -205,6 +207,7 @@
 <script>
     const onboardingUsernameInput = document.getElementById('onboardingUsernameInput');
     const enterButton = document.getElementById('enterButton');
+    const createRoomButton = document.getElementById('createRoomButton')
     const onboardingContainer = document.getElementById('onboardingContainer');
     const chatContainer = document.getElementById('chatContainer');
     const usernameInput = document.getElementById('usernameInput');
@@ -339,7 +342,7 @@
         usernameInput.value = userName
 
         // TODO: env 및 도메인으로 변경
-        ws = new WebSocket(`ws://34.64.139.68:8000/chat/connect`);
+        ws = new WebSocket(`ws://localhost:8000/chat/connect`);
 
         ws.onmessage = function (event) {
             const data = JSON.parse(event.data);
@@ -362,6 +365,43 @@
         chatContainer.classList.remove('hidden');
     });
 
+    createRoomButton.addEventListener('click', function() {
+        const username = document.getElementById('onboardingUsernameInput').value;
+
+        if (!username) {
+            alert('사용자 이름을 입력하세요.');
+            return;
+        }
+
+        setUserName(username);
+        usernameInput.value = userName;
+
+        ws = new WebSocket(`ws://localhost:8000/chat/new/connect`);
+
+        ws.onopen = function () {
+            ws.send(JSON.stringify({username: "System", message: `${username}님이 채팅방을 생성했습니다.`}));
+        };
+
+        ws.onmessage = function (event) {
+            const data = JSON.parse(event.data);
+            if (data.username === "System")
+                addMessage(`${data.username}: ${data.message}`, "10:46 AM", true);
+            else
+                addMessage(`${data.username}: ${data.message}`, "10:46 AM", false);
+        };
+
+        ws.onclose = function (event) {
+            const message = document.createElement('div');
+            message.classList.add('message');
+            message.textContent = "연결이 종료되었습니다.";
+
+            messages.appendChild(message);
+            messages.scrollTop = messages.scrollHeight;
+        };
+
+        onboardingContainer.classList.add('hidden');
+        chatContainer.classList.remove('hidden');
+    });
 
     document.getElementById('sendButton').addEventListener('click', function () {
         sendMessage();

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -13,7 +13,6 @@
         <p id="error" class="text-red-500 mb-1 hidden">사용자 이름을 입력해주세요.</p>
         <input type="text" id="onboardingUsernameInput" placeholder="사용자 이름"
                class="w-full mb-4 p-2 rounded border border-gray-300 focus:outline-none focus:ring focus:border-blue-500">
-        <button id="enterButton" class="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600">입장</button>
         <button id="createRoomButton" class="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600">새 채팅방 만들기</button>
         <button id="joinRoomButton" class="w-full bg-green-500 text-white py-2 rounded hover:bg-green-600 mt-2">기존 채팅방에 참여하기</button>
     </div>
@@ -214,7 +213,6 @@
 </div>
 <script>
     const onboardingUsernameInput = document.getElementById('onboardingUsernameInput');
-    const enterButton = document.getElementById('enterButton');
     const createRoomButton = document.getElementById('createRoomButton');
     const joinRoomButton = document.getElementById('joinRoomButton');
     const backButton = document.getElementById('backButton');

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -260,13 +260,6 @@
         timestampElement.classList.add('mt-2', 'text-xs');
         messageLayout.appendChild(timestampElement);
         messageElement.appendChild(messageLayout);
-        const senderIcon = document.createElement('span');
-        senderIcon.classList.add('relative', 'flex', 'h-10', 'w-10', 'overflow-hidden', 'rounded-full', 'shrink-0');
-        const senderInitials = document.createElement('span');
-        senderInitials.classList.add('flex', 'h-full', 'w-full', 'items-center', 'justify-center', 'rounded-full', 'bg-muted');
-        senderInitials.textContent = 'CN'; // 여기에 보낸 사람의 이니셜을 넣으십시오.
-        senderIcon.appendChild(senderInitials);
-        messageElement.appendChild(senderIcon);
         return messageElement;
     }
 


### PR DESCRIPTION
# 변경사항

1. TODO로 표시된 main.py부분에 실제 username을 넣었습니다. 클라이언트에서 서버 요청을 보낼때 URL에 같이 담기게 해서 처리했습니다.
2. 자기가 친 채팅에 대해서 오른쪽 이니셜 부분을 삭제했습니다.
3. 자기가 친 채팅에 대해서 자신의 이름을 삭제했습니다.
4. 자신 이름을 좌 상단에 나오게 했습니다.
5. 방 이름을 uuid로 128bit로 하지 말고, 이 값을 int로 바꾼다음 10000으로 나눈 나머지값으로 처리했습니다.
6. 채팅 방에 들어갈 때 자신이 속한 방이 표시될 수 있도록 자바스크립트 코드를 room-title h2 element로 처리햇습니다.
7. 새로운 채팅방 생성 기능을 추가했습니다.
8. 기존 채팅방에 들어갈 수 있는 기능을 추가했습니다.
9. 현재 채팅방의 목록을 보여줄 수 있는 api를 추가했습니다.

## 참고사항
리뷰 언제든 환영