### PR TITLE
채팅방 생성 로직 플로우 개선

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,9 +77,8 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
         username=username,
     )
 
-    await chat_rooms[room_id].connect(connection)
-
     try:
+        await chat_rooms[room_id].connect(connection)
         # 클라이언트에게 매개변수를 포함한 초기 메시지 전송
         await chat_rooms[room_id].broadcast(Message(
             username='Root', message=chat_rooms[room_id].room_name
@@ -102,7 +101,8 @@ async def websocket_endpoint(websocket: WebSocket, room_id: str, username: str):
 
 @app.get("/chat/rooms")
 async def get_rooms():
-    return [value.room_name for value in chat_rooms.values()]
+    # TODO: 임시로 room_id를 사용합니다. 추후 ChatRoom response를 추가하고 개선합니다.
+    return [value.room_id for value in chat_rooms.values()]
 
 
 # root

--- a/main.py
+++ b/main.py
@@ -10,8 +10,8 @@ from starlette.templating import Jinja2Templates
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from connection_manager import ConnectionManager
+from emotion_classifier import EmotionClassifier
 from message import Message
-from mock_emotion_classifier import MockEmotionClassifier
 from user_connection import UserConnection
 
 app = FastAPI()
@@ -20,9 +20,12 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 connection_manager = ConnectionManager()
 
-# emotion_classifier = EmotionClassifier()
+emotion_classifier = EmotionClassifier()
+
+
 # m1 import 이슈로 작업할 때는 MockEmotionClassifier 사용
-emotion_classifier = MockEmotionClassifier()
+# main에 merge 되지 않도록 주의해주세요!
+# emotion_classifier = MockEmotionClassifier()
 
 
 class ChatRoom:

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -287,7 +287,7 @@
 		setUserName(username);
 	}
 
-	createRoomButton.addEventListener('click', function () {
+	createRoomButton.addEventListener('click', async function () {
 		const username = document.getElementById('onboardingUsernameInput').value;
 		usernameInput.value = username;
 
@@ -295,35 +295,22 @@
 			alert('사용자 이름을 입력해주세요.');
 			return;
 		}
+		setUserName(username);
 
 		onboardingContainer.classList.add('hidden');
 		chatContainer.classList.remove('hidden');
 
-		ws = new WebSocket(`${socketEndpoint}/chat/connect/new/${username}`);
+		const response = await fetch(`${apiEndpoint}/chat/rooms/new`, {
+			method: 'POST',
+		})
 
-		ws.onopen = function () {
-			console.log("Connected to WebSocket server");
-		};
+		if (response.status >= 400) {
+			alert('채팅방 생성에 실패했습니다.')
+			return
+		}
 
-		ws.onmessage = function (event) {
-			const message = JSON.parse(event.data);
-			if (message.username === "Root") {
-				roomName.innerText = message.message
-			} else {
-				addMessage(message.username, message.message, new Date().toLocaleTimeString());
-			}
-		};
-
-		ws.onclose = function () {
-			console.log("WebSocket connection closed");
-			ws = null;
-		};
-
-		ws.onerror = function (error) {
-			console.error("WebSocket error:", error);
-		};
-
-		setUserName(username);
+		const {room_id} = await response.json()
+		await joinRoom(room_id)
 	});
 
 	joinRoomButton.addEventListener('click', async function () {


### PR DESCRIPTION
### Summary

- 채팅방 생성 로직 플로우를 개선합니다.
  - 기존 채팅방 생성과 socket connection을 바로 하던 로직을 분류합니다.
  - AS-IS 와 TO-BE에 대한 자세한 내용은 https://github.com/BOAZ-ODTT/emotional-analysis-chat/issues/10 에서 확인할 수 있습니다.


### Fyi

- 로직 정상 동작을 위해 채팅방 목록 조회에서 임시로 room_id를 응답에 사용합니다. #13 에서 관련 수정 작업을 진행할 예정입니다.



@falconlee236 빠른 작업을 위해 이것도 바로 merge합니다! 추후에 코드 리뷰 부탁해요!